### PR TITLE
Fix repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "github.com/elius94/photo-sphere-viewer-lensflare-plugin"
+    "url": "https://github.com/Elius94/psv-lens-flare-plugin.git"
   },
   "keywords": [
     "photo-sphere-viewer",


### PR DESCRIPTION
Currently npmjs.org https://www.npmjs.com/package/photo-sphere-viewer-lensflare-plugin does not link to this repository